### PR TITLE
fix(hooks): force LF on shell scripts via .gitattributes (EVO-63622)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-pace-maker",
   "description": "Usage observability, adaptive pacing, and Langfuse telemetry for Claude Code",
-  "version": "2.32.2",
+  "version": "2.32.3",
   "author": {
     "name": "LightspeedDMS"
   }

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Shell scripts must always check out with LF line endings, even on machines
+# where core.autocrlf=true (e.g. Windows, or a plugin-install/packaging
+# environment). The repo stores these files as LF, but an autocrlf=true
+# checkout rewrites them to CRLF, which bash cannot parse — breaking every
+# hook (hook.sh runs on UserPromptSubmit and blocks the prompt). See EVO-63622.
+*.sh text eol=lf

--- a/src/pacemaker/__init__.py
+++ b/src/pacemaker/__init__.py
@@ -1,3 +1,3 @@
 """Claude Pace Maker - Credit-Aware Adaptive Throttling."""
 
-__version__ = "2.32.2"
+__version__ = "2.32.3"


### PR DESCRIPTION
The .sh hooks are stored in the repo as LF, but with core.autocrlf=true (the Windows default, and present in the plugin-install/checkout environment) git rewrites them to CRLF on checkout. bash cannot parse the carriage returns, so hook.sh fails; because it runs on UserPromptSubmit the failure blocks every prompt and makes Claude Code unusable on affected machines.

Add .gitattributes (*.sh text eol=lf) so shell scripts always check out as LF regardless of the consumer's core.autocrlf, making line endings deterministic for the marketplace install.

Bump 2.32.2 -> 2.32.3 (plugin.json + src/pacemaker/__init__.py) so the fix ships to existing installs (explicit version gates plugin updates).